### PR TITLE
fix: make deriveAddress consistently throw errors

### DIFF
--- a/server/io/addDescriptor.js
+++ b/server/io/addDescriptor.js
@@ -43,10 +43,11 @@ export default async ({ data, io }) => {
   }
 
   // Validate by trying to derive the first address
-  const testAddress = deriveAddress(data.descriptor, 0);
-  if (!testAddress) {
-    logger.error(`Invalid descriptor: Could not derive address`);
-    return { error: "Invalid descriptor: Could not derive address" };
+  try {
+    deriveAddress(data.descriptor, 0);
+  } catch (error) {
+    logger.error(`Invalid descriptor: ${error.message}`);
+    return { error: `Invalid descriptor: ${error.message}` };
   }
 
   // If the descriptor is just an extended key, wrap it in the appropriate format

--- a/server/io/editDescriptor.js
+++ b/server/io/editDescriptor.js
@@ -45,10 +45,11 @@ export default async ({ data, io }) => {
   }
 
   // Validate by trying to derive the first address
-  const testAddress = deriveAddress(data.descriptor, 0);
-  if (!testAddress) {
-    logger.error(`Invalid descriptor: Could not derive address`);
-    return { error: "Invalid descriptor: Could not derive address" };
+  try {
+    deriveAddress(data.descriptor, 0);
+  } catch (error) {
+    logger.error(`Invalid descriptor: ${error.message}`);
+    return { error: `Invalid descriptor: ${error.message}` };
   }
   // Get all addresses in one batch
   const allAddressesResult = await deriveAddresses(

--- a/server/lib/descriptors.js
+++ b/server/lib/descriptors.js
@@ -221,15 +221,16 @@ export const deriveAddresses = (descriptor, startIndex, count, skip = 0) => {
   const addresses = [];
   for (let i = 0; i < count; i++) {
     const index = startIndex + skip + i;
-    const address = deriveAddress(descriptor, index);
-    if (!address) {
-      logger.error(`Failed to derive address at index ${index}`);
+    try {
+      const address = deriveAddress(descriptor, index);
+      addresses.push(address);
+    } catch (error) {
+      logger.error(`Failed to derive address at index ${index}: ${error.message}`);
       return {
         success: false,
-        error: `Failed to derive address at index ${index}`,
+        error: `Failed to derive address at index ${index}: ${error.message}`,
       };
     }
-    addresses.push(address);
   }
   return {
     success: true,
@@ -330,8 +331,7 @@ export const deriveAddress = (descriptor, index) => {
   }
 
   if (!payment?.address) {
-    logger.error("Failed to generate address");
-    return null;
+    throw new Error("Failed to generate address");
   }
 
   return {


### PR DESCRIPTION
Updated deriveAddress function to always throw errors instead of inconsistently logging with logger.error and returning null.

Updated all call sites to handle thrown errors with try-catch blocks.