### PR TITLE
[codex] Improve Telegram bot actions

### DIFF
--- a/server/lib/detectBalanceChanges.js
+++ b/server/lib/detectBalanceChanges.js
@@ -43,6 +43,7 @@ export default (address, balance, collectionName, addressName) => {
 
   // Check for changes that need alerts
   const changes = {};
+  const alertChanges = {};
   const shouldAutoAccept = (type) => {
     if (!addr.monitor) return false; // Default to alert if no monitor settings
     return addr.monitor[type] === "auto-accept";
@@ -65,6 +66,7 @@ export default (address, balance, collectionName, addressName) => {
       logger.info(
         `alert chain_in (${newBalance.chain_in}) for ${address} (${collectionName}/${addressName})`
       );
+      alertChanges.chain_in = newBalance.chain_in;
       addr.alerted.chain_in = true;
     }
   }
@@ -84,6 +86,7 @@ export default (address, balance, collectionName, addressName) => {
       logger.info(
         `alert chain_out (${newBalance.chain_out}) for ${address} (${collectionName}/${addressName})`
       );
+      alertChanges.chain_out = newBalance.chain_out;
       addr.alerted.chain_out = true;
     }
   }
@@ -103,6 +106,7 @@ export default (address, balance, collectionName, addressName) => {
       logger.info(
         `alert mempool_in (${newBalance.mempool_in}) for ${address} (${collectionName}/${addressName})`
       );
+      alertChanges.mempool_in = newBalance.mempool_in;
       addr.alerted.mempool_in = true;
     }
   }
@@ -122,6 +126,7 @@ export default (address, balance, collectionName, addressName) => {
       logger.info(
         `alert mempool_out (${newBalance.mempool_out}) for ${address} (${collectionName}/${addressName})`
       );
+      alertChanges.mempool_out = newBalance.mempool_out;
       addr.alerted.mempool_out = true;
     }
   }
@@ -138,14 +143,6 @@ Previous: chain_in=${oldBalance.chain_in}, chain_out=${oldBalance.chain_out}, me
 
     // Save the database if changes were detected
     memory.saveDb();
-  }
-
-  // Only return changes that need alerts and haven't been alerted yet
-  const alertChanges = {};
-  for (const [type, value] of Object.entries(changes)) {
-    if (!shouldAutoAccept(type) && !addr.alerted[type]) {
-      alertChanges[type] = value;
-    }
   }
 
   return Object.keys(alertChanges).length > 0 ? alertChanges : null;

--- a/server/lib/telegram.js
+++ b/server/lib/telegram.js
@@ -1,6 +1,14 @@
 import memory from "./memory.js";
 import logger from "./logger.js";
 import TelegramBot from "node-telegram-bot-api";
+import {
+  acceptChanges,
+  addAddressFromCommand,
+  getAddressMessage,
+  getStatusMessage,
+  getTelegramHelp,
+  refreshAddress,
+} from "./telegramActions.js";
 
 let bot = null;
 let isConnected = false;
@@ -12,6 +20,13 @@ const RECONNECT_BACKOFF = 5000;
 
 // Keep track of alerts we've already sent
 const sentAlerts = new Map();
+
+const escapeHtml = (value) =>
+  `${value ?? ""}`
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
 
 const cleanup = async () => {
   if (bot) {
@@ -83,6 +98,7 @@ const init = async (sendTestMessage = false) => {
       on: (_event, _callback) =>
         logger.info(`Test bot: ${_event} handler registered`),
       sendMessage: (_chatId, _message, _options) => Promise.resolve(true),
+      sendDocument: (_chatId, _document, _options) => Promise.resolve(true),
       getMe: () => Promise.resolve(true),
     };
     isConnected = true;
@@ -120,7 +136,7 @@ const init = async (sendTestMessage = false) => {
     return { success: false, error: "Invalid Telegram token" };
   }
 
-  bot.onText(/\/start/, async (msg) => {
+  bot.onText(/\/start(?:@\w+)?$/, async (msg) => {
     const chatId = msg.chat.id;
     const message = `👋 Welcome to Bitwatch!\n\nYour chat ID is: <code>${chatId}</code>\n\nTo receive notifications:\n1. Copy this chat ID\n2. Paste it in the Bitwatch Telegram configuration\n3. Click Save to test the connection\n\nCurrent status: ${
       chatId === memory.db.telegram.chatId
@@ -130,8 +146,90 @@ const init = async (sendTestMessage = false) => {
     await bot.sendMessage(chatId, message, { parse_mode: "HTML" });
   });
 
+  const sendConfiguredMessage = async (msg, message, options = {}) => {
+    const chatId = msg.chat.id;
+    if (chatId !== memory.db.telegram.chatId) {
+      await bot.sendMessage(
+        chatId,
+        "❌ This chat is not configured to receive notifications.\nUse /start to get your chat ID and configure it in Bitwatch.",
+        { parse_mode: "HTML" }
+      );
+      return false;
+    }
+
+    await bot.sendMessage(chatId, message, {
+      parse_mode: "HTML",
+      disable_web_page_preview: true,
+      ...options,
+    });
+    return true;
+  };
+
+  const sendCommandResult = async (msg, result) => {
+    await sendConfiguredMessage(
+      msg,
+      result.error ? `❌ ${escapeHtml(result.error)}` : result.message
+    );
+  };
+
+  bot.onText(/\/help(?:@\w+)?$/, async (msg) => {
+    await sendConfiguredMessage(msg, getTelegramHelp());
+  });
+
+  bot.onText(/\/status(?:@\w+)?$/, async (msg) => {
+    await sendConfiguredMessage(msg, getStatusMessage());
+  });
+
+  bot.onText(/\/address(?:@\w+)?(?:\s+(.+))?$/, async (msg, match) => {
+    const query = match?.[1]?.trim();
+    if (!query) {
+      await sendConfiguredMessage(
+        msg,
+        "❌ Usage: /address &lt;name|address|path&gt;"
+      );
+      return;
+    }
+    await sendCommandResult(msg, getAddressMessage(query));
+  });
+
+  bot.onText(/\/accept(?:@\w+)?(?:\s+(.+))?$/, async (msg, match) => {
+    await sendCommandResult(msg, acceptChanges(match?.[1]));
+  });
+
+  bot.onText(/\/addaddress(?:@\w+)?(?:\s+(.+))?$/, async (msg, match) => {
+    await sendCommandResult(msg, addAddressFromCommand(match?.[1]));
+  });
+
+  bot.onText(/\/refresh(?:@\w+)?(?:\s+(.+))?$/, async (msg, match) => {
+    const query = match?.[1]?.trim();
+    if (!query) {
+      await sendConfiguredMessage(
+        msg,
+        "❌ Usage: /refresh &lt;name|address|path&gt;"
+      );
+      return;
+    }
+    await sendCommandResult(msg, refreshAddress(query));
+  });
+
+  bot.onText(/\/backup(?:@\w+)?$/, async (msg) => {
+    const chatId = msg.chat.id;
+    if (chatId !== memory.db.telegram.chatId) {
+      await bot.sendMessage(
+        chatId,
+        "❌ This chat is not configured to receive notifications.\nUse /start to get your chat ID and configure it in Bitwatch.",
+        { parse_mode: "HTML" }
+      );
+      return;
+    }
+
+    await bot.sendDocument(chatId, memory.dbFile, {
+      caption: "Bitwatch database backup",
+    });
+  });
+
   bot.on("message", async (msg) => {
-    if (msg.text.startsWith("/start")) return;
+    if (!msg.text || msg.text.startsWith("/")) return;
     const chatId = msg.chat.id;
     if (chatId !== memory.db.telegram.chatId) {
       await bot.sendMessage(

--- a/server/lib/telegramActions.js
+++ b/server/lib/telegramActions.js
@@ -1,0 +1,330 @@
+import memory from "./memory.js";
+import logger from "./logger.js";
+import enqueue from "./queue/enqueue.js";
+import emitState from "./emitState.js";
+
+const BALANCE_TYPES = [
+  ["chain_in", "Chain In"],
+  ["chain_out", "Chain Out"],
+  ["mempool_in", "Mempool In"],
+  ["mempool_out", "Mempool Out"],
+];
+
+const emptyBalance = {
+  chain_in: 0,
+  chain_out: 0,
+  mempool_in: 0,
+  mempool_out: 0,
+};
+
+const escapeHtml = (value) =>
+  `${value ?? ""}`
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+
+const formatSats = (sats) => {
+  const numericSats = Number(sats) || 0;
+  return `${numericSats.toLocaleString()} sats`;
+};
+
+const getCollectionItems = () =>
+  Object.entries(memory.db.collections || {}).flatMap(
+    ([collectionName, collection]) => {
+      const rootAddresses = (collection.addresses || []).map((address) => ({
+        collectionName,
+        address,
+      }));
+
+      const extendedKeyAddresses = (collection.extendedKeys || []).flatMap(
+        (extendedKey) =>
+          (extendedKey.addresses || []).map((address) => ({
+            collectionName,
+            extendedKeyName: extendedKey.name,
+            address,
+          }))
+      );
+
+      const descriptorAddresses = (collection.descriptors || []).flatMap(
+        (descriptor) =>
+          (descriptor.addresses || []).map((address) => ({
+            collectionName,
+            descriptorName: descriptor.name,
+            address,
+          }))
+      );
+
+      return [...rootAddresses, ...extendedKeyAddresses, ...descriptorAddresses];
+    }
+  );
+
+const getItemPath = (item) =>
+  [
+    item.collectionName,
+    item.extendedKeyName || item.descriptorName,
+    item.address.name,
+  ]
+    .filter(Boolean)
+    .join("/");
+
+const getBalanceChanges = (address) => {
+  if (!address.actual) return [];
+
+  const actual = { ...emptyBalance, ...address.actual };
+  const expected = { ...emptyBalance, ...address.expect };
+
+  return BALANCE_TYPES.flatMap(([type, label]) => {
+    if (actual[type] === expected[type]) return [];
+    const diff = actual[type] - expected[type];
+    return [
+      {
+        type,
+        label,
+        actual: actual[type],
+        expected: expected[type],
+        diff,
+      },
+    ];
+  });
+};
+
+const findMatches = (query) => {
+  const normalizedQuery = `${query || ""}`.trim().toLowerCase();
+  if (!normalizedQuery) return [];
+
+  return getCollectionItems().filter((item) => {
+    const searchable = [
+      item.address.address,
+      item.address.name,
+      item.collectionName,
+      item.extendedKeyName,
+      item.descriptorName,
+      getItemPath(item),
+    ]
+      .filter(Boolean)
+      .join(" ")
+      .toLowerCase();
+
+    return searchable.includes(normalizedQuery);
+  });
+};
+
+const resolveSingleMatch = (query) => {
+  const matches = findMatches(query);
+  if (matches.length === 0) {
+    return { error: `No address matched "${query}".` };
+  }
+  if (matches.length > 1) {
+    const options = matches.slice(0, 8).map((item) => `- ${getItemPath(item)}`);
+    return {
+      error: `Multiple addresses matched "${query}". Try a full address or path.\n${options.join(
+        "\n"
+      )}`,
+    };
+  }
+  return { item: matches[0] };
+};
+
+const formatChangeLines = (changes) =>
+  changes.map(
+    (change) =>
+      `${change.label}: ${formatSats(change.expected)} -> ${formatSats(
+        change.actual
+      )} (${change.diff > 0 ? "+" : ""}${formatSats(change.diff)})`
+  );
+
+const acceptItem = (item) => {
+  if (!item.address.actual) return false;
+  item.address.expect = { ...emptyBalance, ...item.address.actual };
+  item.address.alerted = {
+    chain_in: false,
+    chain_out: false,
+    mempool_in: false,
+    mempool_out: false,
+  };
+  return true;
+};
+
+export const getTelegramHelp = () =>
+  [
+    "<b>Bitwatch Telegram commands</b>",
+    "/status - show collection and pending-change summary",
+    "/address &lt;name|address|path&gt; - show address details and balances",
+    "/accept &lt;name|address|path&gt; - accept one address's current balance",
+    "/accept all - accept all pending balance changes",
+    "/addaddress &lt;collection&gt; | &lt;name&gt; | &lt;address&gt; - add a tracked address",
+    "/refresh &lt;name|address|path&gt; - queue a balance refresh",
+    "/backup - download the Bitwatch database",
+  ].join("\n");
+
+export const getStatusMessage = () => {
+  const collections = Object.entries(memory.db.collections || {});
+  const items = getCollectionItems();
+  const pendingItems = items.filter(
+    (item) => getBalanceChanges(item.address).length
+  );
+  const pendingLines = pendingItems
+    .slice(0, 10)
+    .map((item) => `- ${escapeHtml(getItemPath(item))}`);
+
+  return [
+    "<b>Bitwatch Status</b>",
+    `Collections: ${collections.length}`,
+    `Tracked addresses: ${items.length}`,
+    `Pending changes: ${pendingItems.length}`,
+    pendingLines.length ? "" : null,
+    ...pendingLines,
+    pendingItems.length > pendingLines.length
+      ? `...and ${pendingItems.length - pendingLines.length} more`
+      : null,
+  ]
+    .filter((line) => line !== null)
+    .join("\n");
+};
+
+export const getAddressMessage = (query) => {
+  const { item, error } = resolveSingleMatch(query);
+  if (error) return { error };
+
+  const actual = { ...emptyBalance, ...item.address.actual };
+  const expected = { ...emptyBalance, ...item.address.expect };
+  const changes = getBalanceChanges(item.address);
+  const apiEndpoint = memory.db.api || "https://mempool.space";
+
+  const lines = [
+    `<b>${escapeHtml(getItemPath(item))}</b>`,
+    `<a href="${escapeHtml(apiEndpoint)}/address/${escapeHtml(
+      item.address.address
+    )}">${escapeHtml(item.address.address)}</a>`,
+    "",
+    "<b>Actual</b>",
+    ...BALANCE_TYPES.map(
+      ([type, label]) => `${label}: ${formatSats(actual[type])}`
+    ),
+    "",
+    "<b>Expected</b>",
+    ...BALANCE_TYPES.map(
+      ([type, label]) => `${label}: ${formatSats(expected[type])}`
+    ),
+  ];
+
+  if (changes.length) {
+    lines.push("", "<b>Pending changes</b>", ...formatChangeLines(changes));
+  }
+
+  return { message: lines.join("\n") };
+};
+
+export const acceptChanges = (query) => {
+  const normalizedQuery = `${query || ""}`.trim();
+  if (!normalizedQuery) {
+    return { error: "Usage: /accept <name|address|path> or /accept all" };
+  }
+
+  if (normalizedQuery.toLowerCase() === "all") {
+    const pendingItems = getCollectionItems().filter(
+      (item) => getBalanceChanges(item.address).length
+    );
+    pendingItems.forEach(acceptItem);
+    if (pendingItems.length) {
+      memory.saveDb();
+      emitState({ collections: memory.db.collections });
+    }
+    logger.telegram(`Accepted ${pendingItems.length} Telegram balance changes`);
+    return {
+      message: `Accepted ${pendingItems.length} pending balance change${
+        pendingItems.length === 1 ? "" : "s"
+      }.`,
+    };
+  }
+
+  const { item, error } = resolveSingleMatch(normalizedQuery);
+  if (error) return { error };
+
+  const changes = getBalanceChanges(item.address);
+  if (!changes.length) {
+    return {
+      message: `${escapeHtml(getItemPath(item))} has no pending changes.`,
+    };
+  }
+
+  acceptItem(item);
+  memory.saveDb();
+  emitState({ collections: memory.db.collections });
+  logger.telegram(`Accepted Telegram balance change for ${getItemPath(item)}`);
+  return {
+    message: `Accepted current balance for ${escapeHtml(getItemPath(item))}.`,
+  };
+};
+
+export const addAddressFromCommand = (text) => {
+  const parts = `${text || ""}`
+    .split("|")
+    .map((part) => part.trim())
+    .filter(Boolean);
+
+  if (parts.length !== 3) {
+    return {
+      error: "Usage: /addaddress <collection> | <name> | <address>",
+    };
+  }
+
+  const [collectionName, name, address] = parts;
+  const existingAddress = getCollectionItems().find(
+    (item) =>
+      item.collectionName === collectionName && item.address.address === address
+  );
+  if (existingAddress) {
+    return { error: "Address already exists in this collection." };
+  }
+
+  if (!memory.db.collections[collectionName]) {
+    memory.db.collections[collectionName] = {
+      addresses: [],
+      extendedKeys: [],
+      descriptors: [],
+    };
+  }
+
+  const collection = memory.db.collections[collectionName];
+  collection.addresses.push({
+    address,
+    name,
+    expect: { ...emptyBalance },
+    monitor: { ...(memory.db.monitor || {}) },
+    trackWebsocket: false,
+    actual: null,
+    error: false,
+    errorMessage: null,
+  });
+
+  memory.saveDb();
+  enqueue({ collectionName, address });
+  logger.telegram(`Added Telegram address ${collectionName}/${name}`);
+  return {
+    message: `Added ${escapeHtml(collectionName)}/${escapeHtml(
+      name
+    )} and queued a balance refresh.`,
+  };
+};
+
+export const refreshAddress = (query) => {
+  const { item, error } = resolveSingleMatch(query);
+  if (error) return { error };
+
+  enqueue({
+    collectionName: item.collectionName,
+    extendedKeyName: item.extendedKeyName,
+    descriptorName: item.descriptorName,
+    address: item.address.address,
+  });
+
+  return { message: `Queued refresh for ${escapeHtml(getItemPath(item))}.` };
+};
+
+export const _test = {
+  getBalanceChanges,
+  getCollectionItems,
+  findMatches,
+};


### PR DESCRIPTION
## Summary

- Adds Telegram bot commands for status, address details, accepting pending balance changes, adding a single address, refreshing an address, and downloading a database backup.
- Extracts Telegram command behavior into a reusable helper module so command output and balance-change handling can be exercised without Telegram polling.
- Fixes alert-mode balance changes so the first detected alert is returned for Telegram notification instead of being suppressed after the alerted flag is set.

Fixes #15.

## Validation

- `npm exec eslint -- . --max-warnings=0`
- Direct Node check for Telegram status/address helper output
- Direct Node regression check for alert-mode versus auto-accept balance changes

## Note

Full e2e was not run because `npm ci` in `client/` is blocked by the existing mismatch between `client/package.json` and `client/package-lock.json`. The root install and lint pass successfully.