### PR TITLE
Add mempool websocket E2E coverage

### DIFF
--- a/server/io/addAddress.js
+++ b/server/io/addAddress.js
@@ -1,6 +1,7 @@
 import memory from "../lib/memory.js";
 import logger, { getMonitorLog } from "../lib/logger.js";
 import enqueue from "../lib/queue/enqueue.js";
+import mempool from "../lib/mempool.js";
 
 export default async ({ data, io }) => {
   logger.info(
@@ -56,6 +57,10 @@ export default async ({ data, io }) => {
   if (!saveResult) {
     logger.error("addAddress: Failed to save address");
     return { error: "Failed to save address" };
+  }
+
+  if (data.trackWebsocket) {
+    mempool.updateTrackedAddresses();
   }
 
   io.emit("updateState", { collections: memory.db.collections });

--- a/server/lib/mempool.js
+++ b/server/lib/mempool.js
@@ -1,7 +1,7 @@
 import memory from "./memory.js";
 import logger from "./logger.js";
 import handleBalanceUpdate from "./handleBalanceUpdate.js";
-import telegram from "./telegram.js";
+import getAddressObj from "./getAddressObj.js";
 import mempoolJS from "@mempool/mempool.js";
 import { URL } from "url";
 
@@ -191,32 +191,50 @@ const calculateAddressBalance = (transactions, address) => {
 };
 
 const updateAddressBalance = async (address, balance, io) => {
-  // Find the collection and address name
-  let collectionName = null;
-  for (const [name, collection] of Object.entries(memory.db.collections)) {
-    const addr = collection.addresses.find((a) => a.address === address);
-    if (addr) {
-      collectionName = name;
-      break;
-    }
+  const found = getAddressObj({ address });
+  if (!found) {
+    logger.error(`Failed to update balance for ${address}: Address not found`);
+    return false;
   }
 
+  const previousBalance = found.address.actual || {
+    chain_in: 0,
+    chain_out: 0,
+    mempool_in: 0,
+    mempool_out: 0,
+  };
+  const nextBalance = {
+    ...previousBalance,
+    ...balance,
+  };
+
   // Use centralized balance update handler
-  const result = await handleBalanceUpdate(address, balance, collectionName);
+  const result = await handleBalanceUpdate({
+    address,
+    balance: { actual: nextBalance },
+    collectionName: found.collectionName,
+    extendedKeyName: found.extendedKeyName,
+    descriptorName: found.descriptorName,
+  });
   if (result.error) {
     logger.error(`Failed to update balance for ${address}: ${result.error}`);
     return false;
   }
 
-  // If balance changed, emit update for this address
-  if (result.balanceChanged) {
+  const balanceChanged =
+    previousBalance.chain_in !== nextBalance.chain_in ||
+    previousBalance.chain_out !== nextBalance.chain_out ||
+    previousBalance.mempool_in !== nextBalance.mempool_in ||
+    previousBalance.mempool_out !== nextBalance.mempool_out;
+
+  if (balanceChanged) {
     io.emit("updateState", { collections: memory.db.collections });
   }
 
   return true;
 };
 
-const processTransaction = (tx, io) => {
+const processTransaction = async (tx, io) => {
   if (!tx || typeof tx !== "object") return;
 
   // Check inputs and outputs for tracked addresses
@@ -255,7 +273,7 @@ const processTransaction = (tx, io) => {
     // Update each affected address
     for (const address of relevantAddresses) {
       const mempoolBalance = calculateAddressBalance([tx], address);
-      const changes = updateAddressBalance(
+      await updateAddressBalance(
         address,
         {
           mempool_in: mempoolBalance.in,
@@ -263,25 +281,6 @@ const processTransaction = (tx, io) => {
         },
         io
       );
-
-      // If changes were detected and require alerting, notify via Telegram
-      if (changes) {
-        // Find the address in our collections to get its name and collection
-        for (const [collectionName, collection] of Object.entries(
-          memory.db.collections
-        )) {
-          const addr = collection.addresses.find((a) => a.address === address);
-          if (addr) {
-            telegram.notifyBalanceChange(
-              address,
-              changes,
-              collectionName,
-              addr.name
-            );
-            break;
-          }
-        }
-      }
     }
   }
 };
@@ -359,7 +358,7 @@ const setupWebSocket = (io) => {
     updateWebSocketState(io, "CONNECTED");
   });
 
-  ws.addEventListener("message", (event) => {
+  ws.addEventListener("message", async (event) => {
     const data = JSON.parse(event.data);
     if (!data) {
       logger.error("Failed to parse websocket message");
@@ -423,7 +422,7 @@ const setupWebSocket = (io) => {
         );
 
         // Update the address with both chain and mempool values
-        updateAddressBalance(
+        await updateAddressBalance(
           address,
           {
             chain_in: chainBalance.in,
@@ -447,7 +446,9 @@ const setupWebSocket = (io) => {
     // Handle mempool updates
     if (data.transactions) {
       logger.mempool(`Processing ${data.transactions.length} new transactions`);
-      data.transactions.forEach((tx) => processTransaction(tx, io));
+      await Promise.all(
+        data.transactions.map((tx) => processTransaction(tx, io))
+      );
       return;
     }
 

--- a/tests/e2e/api.mock.js
+++ b/tests/e2e/api.mock.js
@@ -13,6 +13,26 @@ let testResponses = new Map(); // Store test responses per address
 
 const responseHeaders = { "Content-Type": "application/json" };
 
+const readJsonBody = (req) =>
+  new Promise((resolve, reject) => {
+    let body = "";
+    req.on("data", (chunk) => {
+      body += chunk;
+    });
+    req.on("end", () => {
+      if (!body) {
+        resolve({});
+        return;
+      }
+      try {
+        resolve(JSON.parse(body));
+      } catch (error) {
+        reject(error);
+      }
+    });
+    req.on("error", reject);
+  });
+
 const log = (level, message) => {
   const timestamp = new Date().toISOString();
   console.log(`[mockAPI] [${timestamp}] [${level}] ${message}`);
@@ -57,6 +77,30 @@ const handleWebSocketConnection = (ws) => {
 };
 
 const handleWebSocketMessage = (ws, message) => {
+  // Handle track-address message used by wsTrackAddress
+  if (message["track-address"]) {
+    const address = message["track-address"];
+    if (address === "stop") {
+      trackedAddresses.clear();
+      log("info", "Stopped tracking addresses");
+      return;
+    }
+
+    trackedAddresses.add(address);
+    log("info", `Tracking address: ${address}`);
+
+    ws.send(
+      JSON.stringify({
+        "multi-address-transactions": {
+          [address]: {
+            confirmed: [],
+            mempool: [],
+          },
+        },
+      })
+    );
+  }
+
   // Handle track-addresses message
   if (message["track-addresses"]) {
     const addresses = message["track-addresses"];
@@ -87,9 +131,29 @@ const handleWebSocketMessage = (ws, message) => {
 };
 
 // HTTP handlers
-const handleHttpRequest = (req, res) => {
+const handleHttpRequest = async (req, res) => {
   try {
     const url = new URL(req.url, `http://${req.headers.host}`);
+
+    if (url.pathname === "/test/tracked-addresses") {
+      res.writeHead(200, responseHeaders);
+      res.end(JSON.stringify({ addresses: [...trackedAddresses] }));
+      return;
+    }
+
+    if (url.pathname === "/test/simulate-transaction") {
+      const { tx } = await readJsonBody(req);
+      if (!tx) {
+        res.writeHead(400, responseHeaders);
+        res.end(JSON.stringify({ error: "Missing tx" }));
+        return;
+      }
+
+      const delivered = simulateTransaction(tx);
+      res.writeHead(200, responseHeaders);
+      res.end(JSON.stringify({ delivered }));
+      return;
+    }
 
     // Handle /api/address/:address endpoint
     if (url.pathname.startsWith("/api/address/")) {
@@ -240,6 +304,7 @@ const simulateTransaction = (tx) => {
         }
       });
     }
+    return relevantAddresses.size;
   } catch (error) {
     log("error", `Error simulating transaction: ${error}`);
     throw error;

--- a/tests/e2e/bitwatch.spec.js
+++ b/tests/e2e/bitwatch.spec.js
@@ -6,6 +6,7 @@ import configurationPage from "./sequences/configurationPage.js";
 import integrationsPage from "./sequences/integrationsPage.js";
 import manageCollections from "./sequences/manageCollections.js";
 import singleAddress from "./sequences/singleAddress.js";
+import mempoolWebsocket from "./sequences/mempoolWebsocket.js";
 import extendedKeys from "./sequences/extendedKeys.js";
 import settings from "./lib/settings.js";
 import descriptors from "./sequences/descriptors.js";
@@ -21,6 +22,7 @@ test.describe("Bitwatch", () => {
     await integrationsPage(page);
     await manageCollections(page);
     await singleAddress(page);
+    await mempoolWebsocket(page);
     await extendedKeys(page);
     await descriptors(page);
     // Now that we've verified all balances, let's verify monitor settings update

--- a/tests/e2e/sequences/mempoolWebsocket.js
+++ b/tests/e2e/sequences/mempoolWebsocket.js
@@ -1,0 +1,68 @@
+import { expect } from "@playwright/test";
+import testData from "../../../test-data/keys.json" with { type: "json" };
+import verifyBalance from "../lib/verifyBalance.js";
+
+const MOCK_API = "http://localhost:3006";
+
+const waitForTrackedAddress = async (address) => {
+  await expect
+    .poll(
+      async () => {
+        const response = await globalThis.fetch(
+          `${MOCK_API}/test/tracked-addresses`
+        );
+        const { addresses } = await response.json();
+        return addresses;
+      },
+      { timeout: 10000 }
+    )
+    .toContain(address);
+};
+
+const simulateTransaction = async (tx) => {
+  const response = await globalThis.fetch(`${MOCK_API}/test/simulate-transaction`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ tx }),
+  });
+
+  expect(response.ok).toBe(true);
+  const result = await response.json();
+  expect(result.delivered).toBeGreaterThan(0);
+};
+
+export default async (page) => {
+  const address = testData.plain.zapomatic;
+
+  console.log("Testing mempool websocket activity...");
+  await waitForTrackedAddress(address);
+
+  await simulateTransaction({
+    txid: "websocket-e2e-transaction",
+    vin: [
+      {
+        prevout: {
+          scriptpubkey_address: address,
+          value: 1000,
+        },
+      },
+    ],
+    vout: [
+      {
+        scriptpubkey_address: address,
+        value: 2500,
+      },
+    ],
+  });
+
+  await verifyBalance(page, address, {
+    chain_in: "0.00010000 ₿",
+    chain_out: "0.00001000 ₿",
+    mempool_in: "0.00002500 ₿",
+    mempool_out: "0.00001000 ₿",
+  });
+
+  await expect(page.getByTestId(`${address}-mempool-out-diff`)).toBeVisible();
+  await expect(page.getByTestId(`${address}-accept-button`)).toBeVisible();
+  console.log("Mempool websocket activity verified");
+};

--- a/tests/e2e/sequences/mempoolWebsocket.js
+++ b/tests/e2e/sequences/mempoolWebsocket.js
@@ -62,7 +62,9 @@ export default async (page) => {
     mempool_out: "0.00001000 ₿",
   });
 
-  await expect(page.getByTestId(`${address}-mempool-out-diff`)).toBeVisible();
+  await expect(page.getByTestId(`${address}-mempool-out-diff`)).toHaveText(
+    "(+0.00001000 ₿)"
+  );
   await expect(page.getByTestId(`${address}-accept-button`)).toBeVisible();
   console.log("Mempool websocket activity verified");
 };

--- a/tests/e2e/sequences/singleAddress.js
+++ b/tests/e2e/sequences/singleAddress.js
@@ -7,7 +7,7 @@ import testData from "../../../test-data/keys.json" with { type: "json" };
 const addAddress = async (
   page,
   collection,
-  { name, address, monitor }
+  { name, address, monitor, trackWebsocket = false }
 ) => {
   await findAndClick(page, `${collection}-add-address`);
 
@@ -20,6 +20,10 @@ const addAddress = async (
   // Fill in the form fields
   await page.getByTestId("address-name-input").fill(name);
   await page.getByTestId("address-input").fill(address);
+
+  if (trackWebsocket) {
+    await page.getByTestId("track-websocket-switch").click();
+  }
 
   // Set monitoring options if provided
   if (monitor) {
@@ -72,6 +76,7 @@ export default async (page) => {
   await addAddress(page, "Donations", {
     name: "zapomatic",
     address: testData.plain.zapomatic,
+    trackWebsocket: true,
     monitor: {
       chain_in: "auto-accept",
       chain_out: "alert",


### PR DESCRIPTION
## Summary
- add E2E coverage for mempool websocket address tracking and transaction updates
- teach the mock mempool server to expose tracked-address state and drive synthetic websocket transactions
- fix websocket balance updates to use the centralized balance handler with the right address context and balance shape

Closes #14.

## Verification
- `npx eslint . --max-warnings=0`
- Manual websocket smoke test with mock mempool API + Bitwatch test server: add a tracked address over Socket.IO, verify mock tracked-address state, simulate a mempool transaction, and verify live state actual balances update to mempool_in=2500/mempool_out=1000.

Note: `npm run test:e2e` could not be completed locally because the Playwright runner repeatedly hung before starting configured web servers; no server ports were opened and no Playwright artifacts were produced.
